### PR TITLE
Fix typo in alloc_and_write_wstring calling non-existent method

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/util.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/util.rb
@@ -401,13 +401,12 @@ class  Util
   #
   # Write Unicode strings to memory.
   #
-  # Given a Unicode string, returns a pointer to a null terminated WCHARs array.
-  # InitializeUnicodeStr(&uStr, sL"string");
+  # Given a string, returns a pointer to a null terminated WCHARs array.
   #
   def alloc_and_write_wstring(value)
     return nil if value.nil?
 
-    alloc_and_write_data(str_to_uniz_a(value))
+    alloc_and_write_data(str_to_uni_z(value))
   end
 
   alias free_wstring free_data


### PR DESCRIPTION
`str_to_uniz_a` does not exist, updated to `str_to_uni_z`. Looking at cross-references, only two modules use this method to convert from ruby strings to null-terminated WCHARs. Updated the comments to clarify usage of this method and fixed the typo.

Fixes #18752